### PR TITLE
corrected singlePress state change in ButtonContext

### DIFF
--- a/Source/cs505/group1/state/ButtonContext.java
+++ b/Source/cs505/group1/state/ButtonContext.java
@@ -32,7 +32,7 @@ public class ButtonContext {
      * current state.  
      */
     public void singlePress(){
-      this.buttonState.singlePress();
+      buttonState = buttonState.singlePress();
     };
     
     /**


### PR DESCRIPTION
Corrected an error in which state changes in the concrete subclasses were not updating ButtonContext.buttonState for the singlePress methods.